### PR TITLE
AS-312: Evita que los th se separen en dos líneas al bajar la resolución

### DIFF
--- a/Source/Locompro/wwwroot/css/SearchResults.css
+++ b/Source/Locompro/wwwroot/css/SearchResults.css
@@ -8,6 +8,9 @@
     margin-right: 0px;
 }
 
+th {
+    white-space: nowrap;
+}
 .search-input-group-on-advanced-search {
     .card
 ;


### PR DESCRIPTION
Modifica el SearchResults.css para evitar el wrap del texto en resoluciones bajas
